### PR TITLE
Fix Yarn version incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
     "eslint": "8.7.0",
     "eslint-config-next": "12.0.9",
     "typescript": "4.5.5"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
## Summary
- specify the exact package manager version to ensure Yarn classic is used

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*
- `yarn install` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845bbb06b1083209558c85369f296d3